### PR TITLE
Fix(claims): Check if it's the claim the user is in.

### DIFF
--- a/src/listeners/Flag.ts
+++ b/src/listeners/Flag.ts
@@ -42,7 +42,8 @@ class Flag extends AbstactListener {
           const location = player.getLocation()
           if (!blocks.find((cord) => cord[0] === location.x && cord[2] === location.z)) {
             if (!this.flagged.has(player)) continue
-            const claim = this.flagged.get(player).claim
+            const _claim = this.flagged.get(player).claim
+            if(_claim.id !== claim.id) continue;
             // Emit the player that left the claim.
             this.claims.emit('LeftClaim', {
               player,


### PR DESCRIPTION
Without this, it leads to a problem where if multiple claims are made it would check all claims if they're in the claim and emit such events resulting in the constant sending of `LeftClaim` and `EnteredClaim`